### PR TITLE
fix: Make the extension installable in Chrome 104

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,5 +14,5 @@
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
   },
-  "minimum_chrome_version": "104.0.5107.0"
+  "minimum_chrome_version": "104.0.0.0"
 }


### PR DESCRIPTION
Set minimum Chrome version to 104 to make it installable in Chrome 104